### PR TITLE
fix width argument

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -71,7 +71,7 @@ class GoogleCalendarInterface:
 
         self.details = options.get('details', {})
         # stored as detail, but provided as option: TODO: fix that
-        self.details['width'] = options.get('width', 80)
+        self.details['width'] = options.get('cal_width', 80)
         self._get_cached()
 
         self._select_cals(cal_names)


### PR DESCRIPTION
Fixes printing the description of e.g. agenda.
To see the effect of this PR:
run e.g.
 `gcalcli agenda --details description --width $COLUMNS`
in different terminal sizes, or just e.g.
 `gcalcli agenda --details description --width 40`
and
 `gcalcli agenda --details description --width 80`
with and without this PR.

I realise this repo is not [upstream gcalcli](https://github.com/insanum/gcalcli), but since it's the source for OpenSUSE, I think it makes sense to fix it here too.